### PR TITLE
Fix invalid path when running on windows.

### DIFF
--- a/src/com/zoho/crm/api/Initializer.php
+++ b/src/com/zoho/crm/api/Initializer.php
@@ -88,7 +88,7 @@ class Initializer
             {
                 if(is_null(self::$jsonDetails))
                 {
-                    self::$jsonDetails = json_decode(file_get_contents(explode("src/com", realpath(__DIR__))[0] . Constants::JSON_DETAILS_FILE_PATH), true);
+                    self::$jsonDetails = json_decode(file_get_contents(join("/", [realpath(join("/", [trim(__DIR__, '\\/'), "../../../../.."])), Constants::JSON_DETAILS_FILE_PATH]), true));
                 }
             }
             catch (\Exception $ex)


### PR DESCRIPTION
Correct file path construction for json details file, so that it works in windows and linux.